### PR TITLE
chore(boost)[sc-67852]: Update boost version to 1_77_0

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ on:
     - '**/*.md'
 
 env:
-  BOOST_VERSION: 1.75.0
+  BOOST_VERSION: 1.77.0
 
 jobs:
   build:
@@ -41,7 +41,7 @@ jobs:
           echo ::set-output name=artefact_name::$artefact_name
       - uses: actions/checkout@v2
       - name: Download boost
-        run: wget https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION//./_}.tar.gz
+        run: wget https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION//./_}.tar.gz
       - name: Extract boost
         run: tar xf boost_${BOOST_VERSION//./_}.tar.gz
       - name: Build boost


### PR DESCRIPTION
Boost 1.75 introduces using `statx` without actually verifying whether it's available on the system or not during the build of boost. This causes issues when it's built on a system which has that syscall, or has the syscall but it's unusable and then you try to compile boron in a Docker container which does not.
Boost 1.77 adds compilation and runtime checks to see if not only is statx available but also invoke-able. It's also the most recent version of Boost which does not come with any known issues or required patches.